### PR TITLE
Add option to use Core Exxet rules for Breakage and Fortitude, Fix rounding for half Ki/Magic Accu

### DIFF
--- a/module/actor/abfalterActor.js
+++ b/module/actor/abfalterActor.js
@@ -2022,7 +2022,7 @@ export default class abfalterActor extends Actor {
             system.zeon.fromPow = 260;
         }
         system.maccu.finalFull = Math.floor(system.maccu.base + system.maccu.fromPow + (system.maccu.mult * system.maccu.fromPow) + system.maccu.spec + system.maccu.bonus + system.maccu.temp);
-        system.maccu.finalHalf = Math.floor(system.maccu.finalFull / 2);
+        system.maccu.finalHalf = Math.ceil(system.maccu.finalFull / 10) * 5;
         system.mregen.final = Math.floor(((system.maccu.fromPow * system.mregen.regenmult) + system.mregen.spec + system.mregen.temp + system.mregen.bonus + system.maccu.finalFull) * system.mregen.recoverymult);
         system.mregen.finalMinusMaint = Math.floor(system.mregen.final - system.zeon.dailyMaint);
         system.zeon.max = Math.floor(system.zeon.base + system.zeon.fromPow + system.zeon.class + system.zeon.spec + system.zeon.temp + system.zeon.bonus);

--- a/module/actor/abfalterCharacterSheet.mjs
+++ b/module/actor/abfalterCharacterSheet.mjs
@@ -506,12 +506,12 @@ export default class abfalterCharacterSheet extends foundry.applications.api.Han
     }
 
     static #kiAccuHalf(ev) {
-        let value = this.document.system.kiPool.agi.current + Math.max(1, Math.floor(this.document.system.kiPool.agi.accumTot / 2));
-        let value2 = this.document.system.kiPool.con.current + Math.max(1, Math.floor(this.document.system.kiPool.con.accumTot / 2));
-        let value3 = this.document.system.kiPool.dex.current + Math.max(1, Math.floor(this.document.system.kiPool.dex.accumTot / 2));
-        let value4 = this.document.system.kiPool.str.current + Math.max(1, Math.floor(this.document.system.kiPool.str.accumTot / 2));
-        let value5 = this.document.system.kiPool.pow.current + Math.max(1, Math.floor(this.document.system.kiPool.pow.accumTot / 2));
-        let value6 = this.document.system.kiPool.wp.current + Math.max(1, Math.floor(this.document.system.kiPool.wp.accumTot / 2));
+        let value = this.document.system.kiPool.agi.current + Math.max(1, Math.ceil(this.document.system.kiPool.agi.accumTot / 2));
+        let value2 = this.document.system.kiPool.con.current + Math.max(1, Math.ceil(this.document.system.kiPool.con.accumTot / 2));
+        let value3 = this.document.system.kiPool.dex.current + Math.max(1, Math.ceil(this.document.system.kiPool.dex.accumTot / 2));
+        let value4 = this.document.system.kiPool.str.current + Math.max(1, Math.ceil(this.document.system.kiPool.str.accumTot / 2));
+        let value5 = this.document.system.kiPool.pow.current + Math.max(1, Math.ceil(this.document.system.kiPool.pow.accumTot / 2));
+        let value6 = this.document.system.kiPool.wp.current + Math.max(1, Math.ceil(this.document.system.kiPool.wp.accumTot / 2));
         this.document.update({
             "system.kiPool.agi.current": value, "system.kiPool.con.current": value2, "system.kiPool.dex.current": value3,
             "system.kiPool.str.current": value4, "system.kiPool.pow.current": value5, "system.kiPool.wp.current": value6

--- a/module/item/abfalterItem.js
+++ b/module/item/abfalterItem.js
@@ -18,7 +18,11 @@ export default class abfalterItem extends Item {
 
         this.system.qualityValue = Math.floor(this.system.quality / 5);
         this.system.derived.presence = Math.floor(+(this.system.qualityValue * 50) + +this.system.presence); 
-        this.system.derived.fortitude = Math.floor(+(this.system.qualityValue * 10) + +this.system.fortitude + this.system.kiBonusFort); 
+        if (game.settings.get('abfalter', abfalterSettingsKeys.CoreExxet_BreakageFortitude)) {
+            this.system.derived.fortitude = Math.floor(+(this.system.qualityValue * 5) + +this.system.fortitude + this.system.kiBonusFort);
+        } else {
+            this.system.derived.fortitude = Math.floor(+(this.system.qualityValue * 10) + +this.system.fortitude + this.system.kiBonusFort);
+        }
         this.system.derived.requirement = Math.max(0, Math.floor(+this.system.requirement - +(this.system.qualityValue * 5)));
         this.system.derived.natPenalty = Math.max(0, Math.floor(+this.system.natPenalty - +(this.system.qualityValue * 5)));
         this.system.derived.movePenalty = Math.max(0, Math.floor(+this.system.movePenalty - +this.system.qualityValue));
@@ -120,12 +124,21 @@ export default class abfalterItem extends Item {
                 
 
                 const strFinal = this.parent.system.stats.Strength.final;
-                this.system.breakageStr = 
-                    strFinal >= 15 ? 8 :
-                    strFinal >= 13 ? 6 :
-                    strFinal >= 11 ? 4 :
-                    strFinal >= 10 ? 2 :
-                    strFinal >= 8  ? 1 : 0;
+                if (game.settings.get('abfalter', abfalterSettingsKeys.CoreExxet_BreakageFortitude)) {
+                    this.system.breakageStr = 
+                        strFinal >= 15 ? 5 :
+                        strFinal >= 13 ? 4 :
+                        strFinal >= 11 ? 3 :
+                        strFinal >= 10 ? 2 :
+                        strFinal >= 8  ? 1 : 0;
+                } else {
+                    this.system.breakageStr = 
+                        strFinal >= 15 ? 8 :
+                        strFinal >= 13 ? 6 :
+                        strFinal >= 11 ? 4 :
+                        strFinal >= 10 ? 2 :
+                        strFinal >= 8  ? 1 : 0;
+                }
 
             } else {
                 this.system.melee.bonusDmgMod = 0;
@@ -136,7 +149,11 @@ export default class abfalterItem extends Item {
             }
             this.system.melee.baseDmg = Math.floor(~~this.system.baseDmg + ~~this.system.melee.bonusDmgMod + (~~this.system.quality * 2) + ~~this.system.kiBonusDmg);
             this.system.melee.finalATPen = Math.floor(~~this.system.atPen + Math.floor(~~this.system.quality / 5));
-            this.system.melee.finalBreakage = Math.floor(~~this.system.breakage + ~~this.system.breakageStr + ~~this.system.quality + ~~this.system.kiBonusBreakage);          
+            if (game.settings.get('abfalter', abfalterSettingsKeys.CoreExxet_BreakageFortitude)) {
+                this.system.melee.finalBreakage = Math.floor(~~this.system.breakage + ~~this.system.breakageStr + (Math.floor(~~this.system.quality / 5) * 2) + ~~this.system.kiBonusBreakage);
+            } else {
+                this.system.melee.finalBreakage = Math.floor(~~this.system.breakage + ~~this.system.breakageStr + ~~this.system.quality + ~~this.system.kiBonusBreakage);
+            }
 
             for (let attack of Object.values(this.system.attacks)) {
                 attack.finalAttack   = attack.attack   + (attack.atkOverride ? 0 : this.system.derived.baseAtk);

--- a/module/utilities/abfalterSettings.js
+++ b/module/utilities/abfalterSettings.js
@@ -4,8 +4,9 @@ export var abfalterSettingsKeys;
     abfalterSettingsKeys["Corrected_Fumble"] = "Corrected_Fumble";
     abfalterSettingsKeys["Use_Meters"] = "Use_Meters";
     abfalterSettingsKeys["Change_Theme"] = "Change_Theme";
-	abfalterSettingsKeys["Corrected_OpenRoll"] = "Corrected_OpenRoll";
-	abfalterSettingsKeys["Corrected_InitiativeRoll"] = "Corrected_InitiativeRoll";
+    abfalterSettingsKeys["Corrected_OpenRoll"] = "Corrected_OpenRoll";
+    abfalterSettingsKeys["Corrected_InitiativeRoll"] = "Corrected_InitiativeRoll";
+    abfalterSettingsKeys["CoreExxet_BreakageFortitude"] = "CoreExxet_BreakageFortitude";
 })(abfalterSettingsKeys || (abfalterSettingsKeys = {}));
 export const abfalterSettings = () => {
     game.settings.register('abfalter', "systemMigrationVersion", {
@@ -69,6 +70,14 @@ export const abfalterSettings = () => {
     game.settings.register('abfalter', abfalterSettingsKeys.Corrected_InitiativeRoll, {
         name: game.i18n.localize('abfalter.globalSettings.openRollInitiative'),
         hint: game.i18n.localize('abfalter.globalSettings.openRollInitiativeDetails'),
+        scope: "client",
+        config: true,
+        default: false,
+        type: Boolean
+    });
+    game.settings.register('abfalter', abfalterSettingsKeys.CoreExxet_BreakageFortitude, {
+        name: "Use Core Exxet values for Breakage and Fort",
+        hint: "When toggled on, the modified Breakage and Fortitude values for weapons and armor will be used.",
         scope: "client",
         config: true,
         default: false,


### PR DESCRIPTION
Decided I could probably resolve this one myself and save Lumenita some trouble. Provides a toggle in the game settings for the Core Exxet Breakage and Fortitude rules.

Doesn't include breakage or strength changes for quality ammunition, as those don't seem to be implemented (and upon looking back at the system I'm actually realizing it isn't explicitly stated anywhere how that works? Anima's weird).